### PR TITLE
(GH-16) Fix redirection on root site if not running on port 80

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM nginx:1.17.3-alpine
 LABEL MAINTAINER="BBT Software AG <devadmin@bbtsoftware.ch>"
 
-ENV CHK_URL monitor.tempuri.org
 ENV CHK_DOCKER_API_VERSION v1.38
 ENV CHK_INTERVAL 60
 ENV CHK_MONITOR prtg

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ These environment variables are supported:
 | ENV field              | Example values        | Description                                                                                                                       |
 |------------------------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------|
 | TZ                     | `Europe/Zurich`       | Timezone to set.                                                                                                                  |
-| CHK_URL                | `monitor.tempuri.org` | Base url to use for nginx redirect. This will be set to `http://{CHK_URL}/status.json`.                                           |
 | CHK_DOCKER_API_VERSION | `v1.38`               | Docker API version to use. Default is `v1.38`.                                                                                    |
 | CHK_INTERVAL           | `60`                  | Interval for check in seconds. Default is `60`.                                                                                   |
 | CHK_MONITOR            | `prtg`                | Used monitoring. Defines the format of the `status.json`. Currently supported is `prtg`.                                          |
@@ -70,7 +69,6 @@ services:
       - 80:80
     environment:
       - TZ=Europe/Zurich
-      - CHK_URL=monitor.tempuri.org
       - CHK_DOCKER_API_VERSION=v1.38
       - CHK_INTERVAL=60
       - CHK_MONITOR=prtg
@@ -88,7 +86,6 @@ docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
   -p 80:80 \
   -e TZ=Europe/Zurich \
-  -e CHK_URL=monitor.tempuri.org \
   -e CHK_DOCKER_API_VERSION=v1.38 \
   -e CHK_INTERVAL=60 \
   -e CHK_MONITOR=prtg \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,12 +1,5 @@
 #!/bin/sh
 
-set_redirect_url () {
-    echo
-    echo "Setting redirect url in index.html to 'http://${CHK_URL}/status.json' ..."
-    sed -i "s|{URL}|${CHK_URL}|g" /usr/share/nginx/html/index.html
-    echo " ... done."
-}
-
 start_http () {
     echo
     echo "Starting nginx ..."
@@ -57,8 +50,6 @@ check_services () {
 
     echo $output | jq '.' > /usr/share/nginx/html/status.json
 }
-
-set_redirect_url
 
 start_http
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <html>
     <head>
-        <meta http-equiv="Refresh" content="0; url=http://{URL}/status.json" />
+        <meta http-equiv="Refresh" content="0; url=/status.json" />
     </head>
 </html>


### PR DESCRIPTION
Fix redirection on root site if not running on port 80. Also removes requirement to set `CHK_URL`

Fixes #16 