### PR TITLE
(GH-43) Update to port 8080

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ COPY docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-EXPOSE 80
+EXPOSE 8080
 
 HEALTHCHECK --interval=1m --timeout=3s \
-    CMD curl -f http://localhost/status.json || exit 1
+    CMD curl -f http://localhost:8080/status.json || exit 1

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ docker pull bbtsoftwareag/swarm-monitor
 
 | Port | Protocol | Description                          |
 |------|----------|--------------------------------------|
-|   80 | TCP      | Web-UI which provides `status.json`. |
+| 8080 | TCP      | Web-UI which provides `status.json`. |
 
 ### Configuration
 
@@ -72,7 +72,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     ports:
-      - 80:80
+      - 80:8080
     environment:
       - TZ=Europe/Zurich
       - CHK_DOCKER_API_VERSION=v1.38
@@ -90,7 +90,7 @@ services:
 ```sh
 docker run -d \
   -v /var/run/docker.sock:/var/run/docker.sock \
-  -p 80:80 \
+  -p 80:8080 \
   -e TZ=Europe/Zurich \
   -e CHK_DOCKER_API_VERSION=v1.38 \
   -e CHK_INTERVAL=60 \


### PR DESCRIPTION
Expose and check for port 8080, since this is the port used by the unpriviliged base image as running as an unpriviliged user requires a port higher than 1024.

Fixes #43 